### PR TITLE
chore(docker): switch base image to nvidia/cuda:11.8.0-runtime-ubuntu22.04

### DIFF
--- a/.docker/Dockerfile.app
+++ b/.docker/Dockerfile.app
@@ -25,7 +25,7 @@ ENV GOFLAGS=$GOFLAGS
 RUN /usr/local/go/bin/go generate ./... \
     && /usr/local/go/bin/go build .
 
-FROM ubuntu:22.04 as app
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04 as app
 
 # Setting this argument prevents interactive prompts during the build process
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>